### PR TITLE
Fix BorderlessScene.removeDefaultCSS() method

### DIFF
--- a/src/main/java/com/goxr3plus/fxborderlessscene/borderless/BorderlessPane.java
+++ b/src/main/java/com/goxr3plus/fxborderlessscene/borderless/BorderlessPane.java
@@ -5,16 +5,9 @@ package com.goxr3plus.fxborderlessscene.borderless;
 
 import java.io.IOException;
 
-import javafx.beans.property.BooleanProperty;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
-import javafx.scene.Node;
-import javafx.scene.Parent;
-import javafx.scene.Scene;
 import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.Pane;
-import javafx.stage.Stage;
-import javafx.stage.StageStyle;
 
 /**
  * Undecorated JavaFX Scene with implemented move, resize, minimize, maximize and Aero Snap.

--- a/src/main/java/com/goxr3plus/fxborderlessscene/borderless/BorderlessScene.java
+++ b/src/main/java/com/goxr3plus/fxborderlessscene/borderless/BorderlessScene.java
@@ -6,7 +6,6 @@ package com.goxr3plus.fxborderlessscene.borderless;
 import java.io.IOException;
 
 import javafx.beans.property.BooleanProperty;
-import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -235,7 +234,7 @@ public class BorderlessScene extends Scene {
 	 */
 	public void removeDefaultCSS() {
 
-		this.root.getStylesheets().remove(0);
+		((Parent) this.root.getChildren().get(0)).getStylesheets().remove(0);
 
 	}
 


### PR DESCRIPTION
- Fixed java.lang.IndexOutOfBoundsException on invoke of BorderlessScene.removeDefaultCSS();
- Removed unused imports;